### PR TITLE
Combine things with lists and potentially nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/piever/AlgebraOfGraphics.jl.svg?branch=master)](https://travis-ci.org/piever/AlgebraOfGraphics.jl)
 [![codecov.io](http://codecov.io/github/piever/AlgebraOfGraphics.jl/coverage.svg?branch=master)](http://codecov.io/github/piever/AlgebraOfGraphics.jl?branch=master)
 
-Define a "plotting package agnostic" algebra of graphics based on a few simple building blocks that can be combined using `*` and `+`. Highly experimental proof of concept, which may break often.
+Define a "plotting package agnostic" algebra of graphics based on a few simple building blocks that can be combined using arrays, broadcasting, and `|>` (used to be `+` and `*`). Highly experimental proof of concept, which may break often.
 
 ## Demo
 
@@ -59,13 +59,18 @@ mpg |> table |> cols .|> different_grouping |> plot
 
 ## Pipeline
 
-Under the hood, `primary`, `data`, and `metadata` generate an underspecified `Trace` object. These `Trace`s can be combined with `*` (merging the information), and `+` (making lists of `Trace`s). The two operation interact following the distributive law.
+Under the hood, `primary`, `data`, and `metadata` generate an underspecified `Trace` object. These `Trace`s can be combined with `|>` (merging the information), or put together in lists.
 The framework does not requires that the objects listed in `Traces` are columns. They could be anything that the plotting package can deal with.
 
 ```julia
 using AlgebraOfGraphics: dims
 x = [-pi..0, 0..pi]
 y = [sin cos]
+```
+
+We use broadcasting semantics on `tuple.(x, y)`.
+
+```julia
 spec = data(x, y) |> primary(color = dims(1), linestyle = dims(2))
 plot(spec, linewidth = 10)
 ```

--- a/README.md
+++ b/README.md
@@ -23,27 +23,27 @@ mpg |> table |> cols |> scat |> plot
 
 ![test](https://user-images.githubusercontent.com/6333339/76689571-0add6900-662f-11ea-9881-918ea426e571.png)
 
-Now I can simply add `grp` to do the grouping
+Now I can simply add `grp` to the pipeline to do the grouping.
 
 ```julia
 mpg |> table |> cols |> grp |> scat |> plot
 ```
 
 ![test](https://user-images.githubusercontent.com/6333339/76689579-234d8380-662f-11ea-8626-3071283f96be.png)
-This is almost a recipe with scatter and linear regression :)
-It can be applied to the arguments just by multiplying them
+
+List of traces are automatically supported via broadcasting (note the `.` in `.|>`).
 
 ```julia
 using StatsMakie: linear
 lin = metadata(linear, linewidth = 5)
-mpg |> table |> cols |> scat + lin |> plot
+mpg |> table |> cols .|> [scat, lin] |> plot
 ```
 
 ![test](https://user-images.githubusercontent.com/6333339/77187183-fafcd380-6acb-11ea-89fa-a9e570f2b4dd.png)
-Again, if I multiply by the grouping, I add it to the scene (we filter to avoid a degenerate group).
+Again, we can add grouping to the pipeline (we filter to avoid a degenerate group).
 
 ```julia
-filter(row -> row.Cyl != 5, mpg) |> table |> cols |> scat + lin |> grp |> plot
+filter(row -> row.Cyl != 5, mpg) |> table |> cols |> grp .|> [scat, lin] |> plot
 ```
 
 ![test](https://user-images.githubusercontent.com/6333339/77187043-c426bd80-6acb-11ea-8c4f-bac6a53652e3.png)
@@ -51,8 +51,8 @@ This is a more complex example, where I want to split the scatter,
 but do the linear regression with all the data
 
 ```julia
-different_grouping = (grp |> scat) + lin
-mpg |> table |> cols |> different_grouping |> plot
+different_grouping = [grp |> scat, lin]
+mpg |> table |> cols .|> different_grouping |> plot
 ```
 
 ![test](https://user-images.githubusercontent.com/6333339/77187226-0bad4980-6acc-11ea-8676-cbb7ee08843c.png)

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -21,29 +21,29 @@ mpg |> table |> cols |> scat |> plot
 
 # ![test](https://user-images.githubusercontent.com/6333339/76689571-0add6900-662f-11ea-9881-918ea426e571.png)
 
-# Now I can simply add `grp` to do the grouping
+# Now I can simply add `grp` to the pipeline to do the grouping.
 
 mpg |> table |> cols |> grp |> scat |> plot
 
 # ![test](https://user-images.githubusercontent.com/6333339/76689579-234d8380-662f-11ea-8626-3071283f96be.png)
-# This is almost a recipe with scatter and linear regression :)
-# It can be applied to the arguments just by multiplying them
+#
+# List of traces are automatically supported via broadcasting (note the `.` in `.|>`).
 
 using StatsMakie: linear
 lin = metadata(linear, linewidth = 5)
-mpg |> table |> cols |> scat + lin |> plot
+mpg |> table |> cols .|> [scat, lin] |> plot
 
 # ![test](https://user-images.githubusercontent.com/6333339/77187183-fafcd380-6acb-11ea-89fa-a9e570f2b4dd.png)
-# Again, if I multiply by the grouping, I add it to the scene (we filter to avoid a degenerate group).
+# Again, we can add grouping to the pipeline (we filter to avoid a degenerate group).
 
-filter(row -> row.Cyl != 5, mpg) |> table |> cols |> scat + lin |> grp |> plot
+filter(row -> row.Cyl != 5, mpg) |> table |> cols |> grp .|> [scat, lin] |> plot
 
 # ![test](https://user-images.githubusercontent.com/6333339/77187043-c426bd80-6acb-11ea-8c4f-bac6a53652e3.png)
 # This is a more complex example, where I want to split the scatter,
 # but do the linear regression with all the data
 
-different_grouping = (grp |> scat) + lin
-mpg |> table |> cols |> different_grouping |> plot
+different_grouping = [grp |> scat, lin]
+mpg |> table |> cols .|> different_grouping |> plot
 
 # ![test](https://user-images.githubusercontent.com/6333339/77187226-0bad4980-6acc-11ea-8676-cbb7ee08843c.png)
 #

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -3,7 +3,7 @@
 # [![Build Status](https://travis-ci.org/piever/AlgebraOfGraphics.jl.svg?branch=master)](https://travis-ci.org/piever/AlgebraOfGraphics.jl)
 # [![codecov.io](http://codecov.io/github/piever/AlgebraOfGraphics.jl/coverage.svg?branch=master)](http://codecov.io/github/piever/AlgebraOfGraphics.jl?branch=master)
 
-# Define a "plotting package agnostic" algebra of graphics based on a few simple building blocks that can be combined using `*` and `+`. Highly experimental proof of concept, which may break often.
+# Define a "plotting package agnostic" algebra of graphics based on a few simple building blocks that can be combined using arrays, broadcasting, and `|>` (used to be `+` and `*`). Highly experimental proof of concept, which may break often.
 
 # ## Demo
 
@@ -49,12 +49,13 @@ mpg |> table |> cols .|> different_grouping |> plot
 #
 # ## Pipeline
 
-# Under the hood, `primary`, `data`, and `metadata` generate an underspecified `Trace` object. These `Trace`s can be combined with `*` (merging the information), and `+` (making lists of `Trace`s). The two operation interact following the distributive law.
+# Under the hood, `primary`, `data`, and `metadata` generate an underspecified `Trace` object. These `Trace`s can be combined with `|>` (merging the information), or put together in lists.
 # The framework does not requires that the objects listed in `Traces` are columns. They could be anything that the plotting package can deal with.
 
 using AlgebraOfGraphics: dims
 x = [-pi..0, 0..pi]
 y = [sin cos]
+# We use broadcasting semantics on `tuple.(x, y)`.
 spec = data(x, y) |> primary(color = dims(1), linestyle = dims(2))
 plot(spec, linewidth = 10)
 

--- a/examples/makie.jl
+++ b/examples/makie.jl
@@ -7,8 +7,11 @@ using RDatasets: dataset
 
 iris = dataset("datasets", "iris")
 spec = iris |> table |> data(:SepalLength, :SepalWidth) |> primary(color = :Species)
-s = metadata(Scatter, markersize = 10px) + metadata(linear)
-spec |> s |> plot
+s = [metadata(Scatter, markersize = 10px), metadata(linear)]
+spec .|> s |> plot
+
+spec |> metadata(linewidth = 3) .|> [metadata(Lines), metadata(linear)] |>
+    primary(linestyle = dims(1)) |> plot
 
 plt = spec |> metadata(Wireframe, density) |> plot
 scatter!(plt, spec)

--- a/src/context.jl
+++ b/src/context.jl
@@ -6,7 +6,6 @@ function group(tr::Trace)
     ctx = context(tr)
     return group(ctx, apply_context(ctx, tr))
 end
-group(ts::TraceArray) = group.(ts)
 group(::GroupedContext, t::Trace) = t
 
 apply_context(c::Union{AbstractContext, Nothing}, m::Trace) = m

--- a/src/makie_integration.jl
+++ b/src/makie_integration.jl
@@ -4,14 +4,14 @@ const PlotFunc     = AbstractPlotting.PlotFunc
 const AbstractPlot = AbstractPlotting.AbstractPlot
 
 function AbstractPlotting.plot!(scn::SceneLike, P::PlotFunc, attr:: Attributes, s::Trace)
-    return AbstractPlotting.plot!(scn, P, attr, TraceArray([s]))
+    return AbstractPlotting.plot!(scn, P, attr, [s])
 end
 
 isabstractplot(s) = isa(s, Type) && s <: AbstractPlot
 
-function AbstractPlotting.plot!(scn::SceneLike, P::PlotFunc, attributes::Attributes, ts::TraceArray)
+function AbstractPlotting.plot!(scn::SceneLike, P::PlotFunc, attributes::Attributes, ts::AbstractArray{<:Trace})
     palette = AbstractPlotting.current_default_theme()[:palette]
-    ts = group(ts)
+    ts = map(group, ts)
     rks = rankdicts(ts)
     for trace in ts
         gp = group(trace)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,7 +39,7 @@ end
 
 rankdict(d) = Dict(val => i for (i, val) in enumerate(uniquesorted(vec(d))))
 
-function rankdicts(ts::TraceArray)
+function rankdicts(ts)
     tables = map(t -> primary(group(t)).kwargs, ts) |> jointable
     return map(rankdict, tables)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,9 @@ using RDatasets: dataset
     mpg = dataset("ggplot2", "mpg")
     spec = data(:Cyl, :Hwy) |> primary(color = :Year)
     s = [metadata(color = :red, font = 10), data(markersize = :Year)]
-    res = mpg |> table .|> s |> spec |> group
-    @test first(res.data)[1].metadata == mixedtuple(color = :red, font = 10)
-    @test first(res.data)[2].metadata == mixedtuple()
+    res = map(group, mpg |> table |> spec .|> s)
+    @test res[1].metadata == mixedtuple(color = :red, font = 10)
+    @test res[2].metadata == mixedtuple()
     idx1 = mpg.Year .== 1999
     idx2 = mpg.Year .== 2008
 
@@ -30,8 +30,8 @@ end
 @testset "rankdicts" begin
     mpg = dataset("ggplot2", "mpg")
     spec = data(:Cyl, :Hwy) |> primary(color = :Year)
-    s = metadata(color = :red, font = 10) + data(markersize = :Year)
-    res = mpg |> table |> s |> spec |> group
+    s = [metadata(color = :red, font = 10), data(markersize = :Year)]
+    res = map(group, mpg |> table |> spec .|> s)
     @test rankdicts(res)[:color][2008] == 2
     @test rankdicts(res)[:color][1999] == 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,10 +7,10 @@ using RDatasets: dataset
 @testset "lazy spec" begin
     mpg = dataset("ggplot2", "mpg")
     spec = data(:Cyl, :Hwy) |> primary(color = :Year)
-    s = metadata(color = :red, font = 10) + data(markersize = :Year)
-    res = mpg |> table |> s |> spec |> group
-    @test res[1].metadata == mixedtuple(color = :red, font = 10)
-    @test res[2].metadata == mixedtuple()
+    s = [metadata(color = :red, font = 10), data(markersize = :Year)]
+    res = mpg |> table .|> s |> spec |> group
+    @test first(res.data)[1].metadata == mixedtuple(color = :red, font = 10)
+    @test first(res.data)[2].metadata == mixedtuple()
     idx1 = mpg.Year .== 1999
     idx2 = mpg.Year .== 2008
 


### PR DESCRIPTION
This ditches the `+` overload in favor of lists and broadcasting. Multiple lists can be combined in various ways using `[trace1 trace2] .|> [trace3, trace4]`. When continuing the pipeline the resulting object  (an array of traces) becomes the data of a new trace.